### PR TITLE
Fix for incorrect parameter count

### DIFF
--- a/Editor/Scripts/Utility/SCEditorUtility.cs
+++ b/Editor/Scripts/Utility/SCEditorUtility.cs
@@ -103,6 +103,9 @@ namespace AYellowpaper.SerializedCollections.Editor
             if (getDrawerMethod.GetParameters().Length == 2)
             {
                 return getDrawerMethod.Invoke(type, new object[] { type, isPropertyManagedReferenceType }) != null;
+            } else if(getDrawerMethod.GetParameters().Length == 3)
+            {
+                return getDrawerMethod.Invoke(type, new object[] { type, new Type[0], isPropertyManagedReferenceType }) != null;
             }
             else
             {


### PR DESCRIPTION
Exceptions should no longer appear and the serialized dictionary displays and works as normal in my testing.